### PR TITLE
Add optional remote server name

### DIFF
--- a/lib/git-process/git_lib.rb
+++ b/lib/git-process/git_lib.rb
@@ -65,7 +65,7 @@ module GitProc
 
 
     def server_name
-      @server_name ||= remote_name
+      @server_name ||= config('gitProcess.remoteName') || remote_name
     end
 
 


### PR DESCRIPTION
When working with multiple remotes, git-process currently defaults to the first listed by calling `split(/\n/)[0]` (excerpt below) on the output of git-remote. This list is (seemingly) alphabetical, so I added a config variable to override. This was needed for me, as git-process was trying to attach to my heroku remote instead of origin.

``` ruby
# git_lib.rb

    def remote_name
      unless @remote_name
        remote_str = command(:remote)
        unless remote_str == nil or remote_str.empty?
          @remote_name = remote_str.split(/\n/)[0]
          raise "!@remote_name.is_a? String" unless @remote_name.is_a? String
        end
        logger.debug {"Using remote name of '#{@remote_name}'"}
      end
      @remote_name
    end

```
