### PR TITLE
Added squash commits prompt to tomaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To get full `git help` and manpage support, do:
 
 * `gitProcess.integrationBranch` : The name of the integration branch. Defaults to `master`, but can be set to `develop` or other.
 * `gitProcess.keepLocalIntegrationBranch` : Controls asking about removing the local integration branch. Defaults to 'false' (i.e., do not assume the branch should be there).
+* `gitProcess.squashCommits` : Controls asking about squashing commits when pushing to master.  Defaults to 'false' (i.e., do not prompt user to squash commits).
 * `gitProcess.remoteName` : Explicitly sets the remote server name to use.
 * `gitProcess.defaultRebaseSync`: Should `git sync` default to using rebase instead of merge? Defaults to 'true' (i.e., Sync using rebase.)
 

--- a/lib/git-process/rebase_to_master.rb
+++ b/lib/git-process/rebase_to_master.rb
@@ -39,7 +39,12 @@ module GitProc
       raise UncommittedChangesError.new unless gitlib.status.clean?
       raise ParkedChangesError.new(gitlib) if is_parked?
     end
-
+		
+    def should_squash_commits
+        if ask_about_squashing_commits
+          gitlib.proc_rebase(gitlib.config.integration_branch, :interactive => 'origin/master')
+        end
+    end
 
     def runner
       if remote.exists?
@@ -48,7 +53,9 @@ module GitProc
         unless @pr_number.nil? or @pr_number.empty?
           checkout_pull_request
         end
-
+		
+        should_squash_commits if squash_commits_config_value.to_boolean
+		
         Syncer.rebase_sync(gitlib, true)
         current = gitlib.branches.current.name
         gitlib.push(remote.name, current, config.master_branch)
@@ -128,6 +135,26 @@ module GitProc
       end
     end
 
+    #noinspection RubyInstanceMethodNamingConvention
+    def squash_commits_config_value
+      gitlib.config['gitProcess.squashCommits']
+    end
+	
+    def ask_about_squashing_commits
+      resp = ask("You should squash your commits before pushing to master.  Do you need to do this? (Yn) ") do |q|
+        q.responses[:not_valid] = 'Please respond with either (y)es or (n)o. Defaults to (y)es.'
+        q.case = :down
+        q.default = 'Y'
+        q.validate = /y|n/i
+      end
+
+      if resp == 'n'
+        say("(You can turn off this message using \"git config gitProcess.squashCommits false\").")
+        false
+      else
+        true
+      end
+    end
 
     private
 


### PR DESCRIPTION
Updating to-master command to prompt user to squash commits before continuing with to-master.  Hopefully this will reduce the number of cases where users forget to squash.
