### PR TITLE
Added squash commits prompt to to-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To get full `git help` and manpage support, do:
 
 * `gitProcess.integrationBranch` : The name of the integration branch. Defaults to `master`, but can be set to `develop` or other.
 * `gitProcess.keepLocalIntegrationBranch` : Controls asking about removing the local integration branch. Defaults to 'false' (i.e., do not assume the branch should be there).
+* `gitProcess.squashCommits` : Controls asking about squashing commits when pushing to master.  Defaults to 'false' (i.e., do not prompt user to squash commits).
 * `gitProcess.remoteName` : Explicitly sets the remote server name to use.
 * `gitProcess.defaultRebaseSync`: Should `git sync` default to using rebase instead of merge? Defaults to 'true' (i.e., Sync using rebase.)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To get full `git help` and manpage support, do:
 
 * `gitProcess.integrationBranch` : The name of the integration branch. Defaults to `master`, but can be set to `develop` or other.
 * `gitProcess.keepLocalIntegrationBranch` : Controls asking about removing the local integration branch. Defaults to 'false' (i.e., do not assume the branch should be there).
-* `gitProcess.squashCommits` : Controls asking about squashing commits when pushing to master.  Defaults to 'false' (i.e., do not prompt user to squash commits).
+* `gitProcess.squashCommits` : Controls asking about squashing commits when pushing to master.  Defaults to 'false' (i.e., do not prompt user to squash commits).  Does not support VIM as the interactive rebase editor at this time.
 * `gitProcess.remoteName` : Explicitly sets the remote server name to use.
 * `gitProcess.defaultRebaseSync`: Should `git sync` default to using rebase instead of merge? Defaults to 'true' (i.e., Sync using rebase.)
 

--- a/lib/git-process/git_lib.rb
+++ b/lib/git-process/git_lib.rb
@@ -480,6 +480,9 @@ module GitProc
       args << "-#{opts[:num_revs]}" if opts[:num_revs]
       args << '--oneline' if opts[:oneline]
       args << "#{start_revision}..#{end_revision}"
+      if opts[:count]
+        args << '--count'
+      end
       command('rev-list', args)
     end
 

--- a/lib/git-process/git_process.rb
+++ b/lib/git-process/git_process.rb
@@ -100,7 +100,7 @@ module GitProc
 	
 	
     def commits_since_master
-      Integer(gitlib.rev_list('origin/master','HEAD', :count => []))
+      Integer(gitlib.rev_list('origin/master','HEAD', :count => true))
     end
 
 

--- a/lib/git-process/git_process.rb
+++ b/lib/git-process/git_process.rb
@@ -97,6 +97,11 @@ module GitProc
     def is_parked?
       gitlib.is_parked?
     end
+	
+	
+    def commits_since_master
+	  Integer(gitlib.rev_list('origin/master','HEAD', :count => []))
+    end
 
 
     private

--- a/lib/git-process/git_process.rb
+++ b/lib/git-process/git_process.rb
@@ -100,7 +100,7 @@ module GitProc
 	
 	
     def commits_since_master
-	  Integer(gitlib.rev_list('origin/master','HEAD', :count => []))
+      Integer(gitlib.rev_list('origin/master','HEAD', :count => []))
     end
 
 

--- a/lib/git-process/rebase_to_master.rb
+++ b/lib/git-process/rebase_to_master.rb
@@ -42,11 +42,11 @@ module GitProc
 	
 	
     def should_squash_commits		
-        if commits_since_master > 1
-            if ask_about_squashing_commits
-              gitlib.proc_rebase(gitlib.config.integration_branch, :interactive => 'origin/master')
-            end
+      if commits_since_master > 1
+        if ask_about_squashing_commits
+          gitlib.proc_rebase(gitlib.config.integration_branch, :interactive => 'origin/master')
         end
+      end
     end
 
     def runner

--- a/lib/git-process/rebase_to_master.rb
+++ b/lib/git-process/rebase_to_master.rb
@@ -39,7 +39,12 @@ module GitProc
       raise UncommittedChangesError.new unless gitlib.status.clean?
       raise ParkedChangesError.new(gitlib) if is_parked?
     end
-
+		
+    def should_squash_commits
+        if ask_about_squashing_commits
+          gitlib.proc_rebase(gitlib.config.integration_branch, :interactive => 'origin/master')
+        end
+    end
 
     def runner
       if remote.exists?
@@ -48,7 +53,9 @@ module GitProc
         unless @pr_number.nil? or @pr_number.empty?
           checkout_pull_request
         end
-
+		
+        should_squash_commits if squash_commits_config_value.to_boolean
+		
         Syncer.rebase_sync(gitlib, true)
         current = gitlib.branches.current.name
         gitlib.push(remote.name, current, config.master_branch)
@@ -128,6 +135,26 @@ module GitProc
       end
     end
 
+    #noinspection RubyInstanceMethodNamingConvention
+    def squash_commits_config_value
+      gitlib.config['gitProcess.squashCommits']
+    end
+	
+    def ask_about_squashing_commits
+      resp = ask("You should squash your commits before pushing to master.  Do you need to do this? (Yn) ") do |q|
+        q.responses[:not_valid] = 'Please respond with either (y)es or (n)o. Defaults to (y)es.'
+        q.case = :down
+        q.default = 'Y'
+        q.validate = /y|n/i
+      end
+
+      if resp == 'n'
+        say("(You can turn off this message using \"git config gitProcess.squashCommits false\").")
+        false
+      else
+        true
+      end
+    end
 
     private
 

--- a/lib/git-process/rebase_to_master.rb
+++ b/lib/git-process/rebase_to_master.rb
@@ -39,10 +39,13 @@ module GitProc
       raise UncommittedChangesError.new unless gitlib.status.clean?
       raise ParkedChangesError.new(gitlib) if is_parked?
     end
-		
-    def should_squash_commits
-        if ask_about_squashing_commits
-          gitlib.proc_rebase(gitlib.config.integration_branch, :interactive => 'origin/master')
+	
+	
+    def should_squash_commits		
+        if commits_since_master > 1
+            if ask_about_squashing_commits
+              gitlib.proc_rebase(gitlib.config.integration_branch, :interactive => 'origin/master')
+            end
         end
     end
 

--- a/spec/rebase_to_master_spec.rb
+++ b/spec/rebase_to_master_spec.rb
@@ -51,6 +51,33 @@ describe RebaseToMaster do
     end
 
 
+    it 'should prompt for squash when > 1 commit' do
+      gitlib.branch('fb', :base_branch => 'master')
+      change_file_and_commit('a', '')
+      clone_repo('fb') do |gl|
+        rtm = GitProc::RebaseToMaster.new(gl, :log_level => log_level, :keep => false)
+        rtm.config['gitProcess.squashCommits'] = 'true'
+        rtm.stub(:commits_since_master).and_return(2)
+        rtm.should_receive(:ask_about_squashing_commits)
+        commit_count.should == 2
+        rtm.should_squash_commits
+      end
+    end
+
+    
+    it 'should not prompt for squash when < 2 commits' do
+      gitlib.branch('fb', :base_branch => 'master')
+      clone_repo('fb') do |gl|
+        rtm = GitProc::RebaseToMaster.new(gl, :log_level => log_level, :keep => false)
+        rtm.config['gitProcess.squashCommits'] = 'true'
+        rtm.stub(:commits_since_master).and_return(1)
+        rtm.should_not_receive(:ask_about_squashing_commits)
+        commit_count.should == 1
+        rtm.should_squash_commits
+      end
+    end
+    
+
     describe 'when used on _parking_' do
       it 'should fail #rebase_to_master' do
         gitlib.checkout('_parking_', :new_branch => 'master')


### PR DESCRIPTION
Updating to-master command to prompt user to squash commits before continuing with to-master. Hopefully this will reduce the number of cases where users forget to squash.

Note: Default editor used by interactive rebase may not launch properly on Windows machines.
